### PR TITLE
Add capabilities for logging exception information.

### DIFF
--- a/tests/test_stdlib_formatter.py
+++ b/tests/test_stdlib_formatter.py
@@ -127,4 +127,3 @@ def test_can_limit_stack_traces():
     result = json.loads(formatter.format(record))
     # resulting stack trace should just have 2 lines (i.e. 1 frame)
     assert 2 == len(result['error']['stack_trace'].strip().split('\n'))
-    

--- a/tests/test_stdlib_formatter.py
+++ b/tests/test_stdlib_formatter.py
@@ -16,10 +16,18 @@ def make_record():
         msg="%d: %s",
         args=(1, "hello"),
         func="test_function",
+        process=11,
+        processName="main",
+        thread=12,
+        threadName="Thread1",
         exc_info=None,
     )
     record.created = 1584713566
     record.msecs = 123
+    record.process = 11
+    record.processName = "MainProcess"
+    record.thread = 12
+    record.threadName = "MainThread"
     return record
 
 
@@ -29,7 +37,8 @@ def test_record_formatted():
     assert formatter.format(make_record()) == (
         '{"@timestamp":"2020-03-20T14:12:46.123Z","ecs":{"version":"1.5.0"},'
         '"log":{"level":"debug","logger":"logger-name","origin":{"file":{"line":10,"name":"file.py"},'
-        '"function":"test_function"},"original":"1: hello"},"message":"1: hello"}'
+        '"function":"test_function"},"original":"1: hello"},"message":"1: hello",'
+        '"process":{"name":"MainProcess","pid":11,"thread":{"id":12,"name":"MainThread"}}}'
     )
 
 
@@ -44,7 +53,8 @@ def test_can_be_overridden():
     assert formatter.format(make_record()) == (
         '{"@timestamp":"2020-03-20T14:12:46.123Z","custom":"field","ecs":{"version":"1.5.0"},'
         '"log":{"level":"debug","logger":"logger-name","origin":{"file":{"line":10,"name":"file.py"},'
-        '"function":"test_function"},"original":"1: hello"},"message":"1: hello"}'
+        '"function":"test_function"},"original":"1: hello"},"message":"1: hello",'
+        '"process":{"name":"MainProcess","pid":11,"thread":{"id":12,"name":"MainThread"}}}'
     )
 
 
@@ -58,8 +68,10 @@ def test_can_be_set_on_handler():
     assert stream.getvalue() == (
         '{"@timestamp":"2020-03-20T14:12:46.123Z","ecs":{"version":"1.5.0"},'
         '"log":{"level":"debug","logger":"logger-name","origin":{"file":{"line":10,"name":"file.py"},'
-        '"function":"test_function"},"original":"1: hello"},"message":"1: hello"}\n'
+        '"function":"test_function"},"original":"1: hello"},"message":"1: hello",'
+        '"process":{"name":"MainProcess","pid":11,"thread":{"id":12,"name":"MainThread"}}}\n'
     )
+
 
 @mock.patch("time.time")
 def test_extra_is_merged(time):
@@ -74,56 +86,93 @@ def test_extra_is_merged(time):
 
     logger.info("hey world", extra={"tls": {"cipher": "AES"}, "tls.established": True})
 
-    assert stream.getvalue() == (
-        '{"@timestamp":"2020-03-20T16:16:37.187Z","ecs":{"version":"1.5.0"},"log":'
-        '{"level":"info","logger":"test-logger","origin":{"file":{"line":75,"name":'
-        '"test_stdlib_formatter.py"},"function":"test_extra_is_merged"},"original":"hey '
-        'world"},"message":"hey world","tls":{"cipher":"AES","established":true}}\n'
-    )
+    result = json.loads(stream.getvalue())
+    assert result["tls"]["cipher"] == "AES"
+    assert result["tls"]["established"] is True
+
 
 def test_can_log_exception_info():
-    formatter = ecs_logging.StdlibFormatter(include_exc_info=True)
+    formatter = ecs_logging.StdlibFormatter()
     record = make_record()
     try:
         raise Exception("msg")
-    except:
-        record.exc_info = sys.exc_info()
-        
-    assert formatter.format(record) == (
-        '{"@timestamp":"2020-03-20T14:12:46.123Z","ecs":{"version":"1.5.0"},'
-        '"error":{"message":"msg","type":"Exception"},'
-        '"log":{"level":"debug","logger":"logger-name","origin":{"file":{"line":10,"name":"file.py"},'
-        '"function":"test_function"},"original":"1: hello"},"message":"1: hello"}'
-    )
-
-def test_can_include_stack_traces():
-    formatter = ecs_logging.StdlibFormatter(include_exc_info=True,
-                                            stack_trace_limit=None)
-    record = make_record()
-
-    try:
-        raise Exception("msg")
-    except:
+    except Exception:
         record.exc_info = sys.exc_info()
 
     result = json.loads(formatter.format(record))
-    trace_lines = result['error']['stack_trace'].split('\n')
-    assert re.search("^\\s+File \\\"\\S+ecs-logging-python/tests/test_stdlib_formatter.py\\\", line 105, in test_can_include_stack_traces$", trace_lines[0]) is not None
+    assert result["error"]["message"] == "msg"
+    assert result["error"]["type"] == "Exception"
+
+
+def test_can_include_stack_traces():
+    formatter = ecs_logging.StdlibFormatter(stack_trace_limit=None)
+    record = make_record()
+
+    try:
+        raise Exception("msg")
+    except Exception:
+        record.exc_info = sys.exc_info()
+
+    result = json.loads(formatter.format(record))
+    trace_lines = result["error"]["stack_trace"].split("\n")
+    assert (
+        re.search(
+            '^\\s+File \\"\\S+ecs-logging-python/tests/test_stdlib_formatter.py\\", line 112, in test_can_include_stack_traces$',
+            trace_lines[0],
+        )
+        is not None
+    )
     assert trace_lines[1] == '    raise Exception("msg")'
+
 
 def _generate_exception():
     raise Exception("msg")
 
+
 def test_can_limit_stack_traces():
-    formatter = ecs_logging.StdlibFormatter(include_exc_info=True,
-                                            stack_trace_limit=1)
+    formatter = ecs_logging.StdlibFormatter(stack_trace_limit=1)
     record = make_record()
 
     try:
         _generate_exception()
-    except:
+    except Exception:
         record.exc_info = sys.exc_info()
 
     result = json.loads(formatter.format(record))
     # resulting stack trace should just have 2 lines (i.e. 1 frame)
-    assert 2 == len(result['error']['stack_trace'].strip().split('\n'))
+    assert 2 == len(result["error"]["stack_trace"].strip().split("\n"))
+
+
+def test_records_exceptions_from_logger():
+    stream = StringIO()
+    handler = logging.StreamHandler(stream)
+    handler.setFormatter(ecs_logging.StdlibFormatter())
+    logger = logging.getLogger("test-logger")
+    logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
+
+    try:
+        raise Exception("msg")
+    except Exception:
+        logger.exception("caught exception")
+
+    result = json.loads(stream.getvalue())
+    assert result["message"] == "caught exception"
+    assert result["error"]["type"] == "Exception"
+
+
+def test_can_exclude_keys():
+    formatter = ecs_logging.StdlibFormatter(
+        exclude_keys=[
+            "process.name",
+            "process.pid",
+            "process.thread.id",
+            "process.thread.name",
+        ]
+    )
+
+    assert formatter.format(make_record()) == (
+        '{"@timestamp":"2020-03-20T14:12:46.123Z","ecs":{"version":"1.5.0"},'
+        '"log":{"level":"debug","logger":"logger-name","origin":{"file":{"line":10,"name":"file.py"},'
+        '"function":"test_function"},"original":"1: hello"},"message":"1: hello"}'
+    )


### PR DESCRIPTION
This adds two optional arguments to the constructor of
`StdlibFormatter`:
* `include_exc_info` : if `True`, include exception information
  from the `LogRecord`
* `stack_trace_limit` : if greater than zero, include up to this
  many stack frames from a traceback object, if present. Can be
  set to `None` to include all available frames.

Both of these parameters default to not including the related
exception information, preserving the current behavior of the
formatter.