### PR TITLE
Add exclude_fields and stack_trace_limit to StdlibLogger

### DIFF
--- a/ecs_logging/_stdlib.py
+++ b/ecs_logging/_stdlib.py
@@ -1,27 +1,36 @@
 import logging
 import time
+from traceback import format_tb
 from ._meta import ECS_VERSION
-from ._utils import merge_dicts, de_dot, json_dumps, TYPE_CHECKING
+from ._utils import (
+    merge_dicts,
+    de_dot,
+    json_dumps,
+    TYPE_CHECKING,
+    collections_abc,
+    lru_cache,
+)
 
 if TYPE_CHECKING:
-    from typing import Any, Dict
+    from typing import Optional, Any, Callable, Dict, Sequence
+
+
+# Load the attributes of a LogRecord so if some are
+# added in the future we won't mistake them for 'extra=...'
+try:
+    _LOGRECORD_DIR = set(dir(logging.LogRecord("", 0, "", 0, "", (), None)))
+except Exception:  # LogRecord signature changed?
+    _LOGRECORD_DIR = set()
 
 
 class StdlibFormatter(logging.Formatter):
     """ECS Formatter for the standard library ``logging`` module"""
 
-    WANTED_ATTRS = {
-        "levelname": "log.level",
-        "funcName": "log.origin.function",
-        "lineno": "log.origin.file.line",
-        "filename": "log.origin.file.name",
-        "message": "log.original",
-        "name": "log.logger",
-    }
-    LOGRECORD_DICT = {
+    _LOGRECORD_DICT = {
         "name",
         "msg",
         "args",
+        "asctime",
         "levelname",
         "levelno",
         "pathname",
@@ -39,12 +48,49 @@ class StdlibFormatter(logging.Formatter):
         "threadName",
         "processName",
         "process",
-    }
+        "message",
+    } | _LOGRECORD_DIR
     converter = time.gmtime
 
-    def __init__(self):
-        # type: () -> None
+    def __init__(self, stack_trace_limit=None, exclude_fields=()):
+        # type: (Any, Optional[int], Sequence[str]) -> None
+        """Initialize the ECS formatter.
+
+        :param int stack_trace_limit:
+            Specifies the maximum number of frames to include for stack
+            traces. Defaults to ``None`` which includes all available frames.
+            Setting this to zero will suppress stack traces.
+        :param Sequence[str] exclude_fields:
+            Specifies any fields that should be suppressed from the resulting
+            fields, expressed with dot notation::
+
+                exclude_keys=["error.stack_trace"]
+
+            You can also use field prefixes to exclude whole groups of fields::
+
+                exclude_keys=["error"]
+        """
         super(StdlibFormatter, self).__init__()
+
+        if stack_trace_limit is not None:
+            if not isinstance(stack_trace_limit, int):
+                raise TypeError(
+                    "'stack_trace_limit' must be None, or a non-negative integer"
+                )
+            elif stack_trace_limit < 0:
+                raise ValueError(
+                    "'stack_trace_limit' must be None, or a non-negative integer"
+                )
+
+        if (
+            not isinstance(exclude_fields, collections_abc.Sequence)
+            or isinstance(exclude_fields, str)
+            or any(not isinstance(item, str) for item in exclude_fields)
+        ):
+            raise TypeError("'exclude_fields' must be a sequence of strings")
+
+        self._exclude_fields = frozenset(exclude_fields)
+        self._stack_trace_limit = stack_trace_limit
 
     def format(self, record):
         # type: (logging.LogRecord) -> str
@@ -53,14 +99,51 @@ class StdlibFormatter(logging.Formatter):
 
     def format_to_ecs(self, record):
         # type: (logging.LogRecord) -> Dict[str, Any]
-        """Function that can be overridden to add additional fields
-        to the JSON before being dumped into a string.
+        """Function that can be overridden to add additional fields to
+        (or remove fields from) the JSON before being dumped into a string.
+
+         .. code-block: python
+
+            class MyFormatter(StdlibFormatter):
+                def format_to_ecs(self, record):
+                  result = super().format_to_ecs(record)
+                  del result["log"]["original"]   # remove unwanted field(s)
+                  result["my_field"] = "my_value" # add custom field
+                  return result
         """
-        timestamp = "%s.%03dZ" % (
-            self.formatTime(record, datefmt="%Y-%m-%dT%H:%M:%S"),
-            record.msecs,
-        )
-        result = {"@timestamp": timestamp, "ecs": {"version": ECS_VERSION}}
+
+        extractors = {
+            "@timestamp": self._record_timestamp,
+            "ecs.version": lambda _: ECS_VERSION,
+            "log.level": lambda r: (r.levelname.lower() if r.levelname else None),
+            "log.origin.function": self._record_attribute("funcName"),
+            "log.origin.file.line": self._record_attribute("lineno"),
+            "log.origin.file.name": self._record_attribute("filename"),
+            "log.original": lambda r: r.getMessage(),
+            "log.logger": self._record_attribute("name"),
+            "process.pid": self._record_attribute("process"),
+            "process.name": self._record_attribute("processName"),
+            "process.thread.id": self._record_attribute("thread"),
+            "process.thread.name": self._record_attribute("threadName"),
+            "error.type": lambda r: (
+                r.exc_info[0].__name__
+                if (r.exc_info is not None and r.exc_info[0] is not None)
+                else None
+            ),
+            "error.message": lambda r: (
+                str(r.exc_info[1]) if r.exc_info and r.exc_info[1] else None
+            ),
+            "error.stack_trace": self._record_error_stack_trace,
+        }  # type: Dict[str, Callable[[logging.LogRecord],Any]]
+
+        result = {}  # type: Dict[str, Any]
+        for field in set(extractors.keys()).difference(self._exclude_fields):
+            if self._is_field_excluded(field):
+                continue
+            value = extractors[field](record)
+            if value is not None:
+                merge_dicts(de_dot(field, value), result)
+
         available = record.__dict__
 
         # This is cleverness because 'message' is NOT a member
@@ -69,20 +152,51 @@ class StdlibFormatter(logging.Formatter):
         # adding 'message' to ``available``, it simplifies the code
         available["message"] = record.getMessage()
 
-        for attribute in set(self.WANTED_ATTRS).intersection(available):
-            ecs_attr = self.WANTED_ATTRS[attribute]
-            value = getattr(record, attribute)
-            if ecs_attr == "log.level" and isinstance(value, str):
-                value = value.lower()
-            merge_dicts(de_dot(ecs_attr, value), result)
-
+        extras = set(available).difference(self._LOGRECORD_DICT)
         # Merge in any keys that were set within 'extra={...}'
-        for key in set(available.keys()).difference(self.LOGRECORD_DICT):
-            merge_dicts(de_dot(key, available[key]), result)
+        for field in extras:
+            if self._is_field_excluded(field):
+                continue
+            merge_dicts(de_dot(field, available[field]), result)
 
         # The following is mostly for the ecs format. You can't have 2x
-        # 'message' keys in WANTED_ATTRS, so we set the value to
+        # 'message' keys in _WANTED_ATTRS, so we set the value to
         # 'log.original' in ecs, and this code block guarantees it
         # still appears as 'message' too.
-        result.setdefault("message", available["message"])
+        if not self._is_field_excluded("message"):
+            result.setdefault("message", available["message"])
         return result
+
+    @lru_cache()
+    def _is_field_excluded(self, field):
+        # type: (str) -> bool
+        field_path = []
+        for path in field.split("."):
+            field_path.append(path)
+            if ".".join(field_path) in self._exclude_fields:
+                return True
+        return False
+
+    def _record_timestamp(self, record):
+        # type: (logging.LogRecord) -> str
+        return "%s.%03dZ" % (
+            self.formatTime(record, datefmt="%Y-%m-%dT%H:%M:%S"),
+            record.msecs,
+        )
+
+    def _record_attribute(self, attribute):
+        # type: (str) -> Callable[[logging.LogRecord], Optional[Any]]
+        return lambda r: getattr(r, attribute, None)
+
+    def _record_error_stack_trace(self, record):
+        # type: (logging.LogRecord) -> Optional[str]
+        if not (
+            record.exc_info
+            and record.exc_info[2] is not None
+            and (self._stack_trace_limit is None or self._stack_trace_limit > 0)
+        ):
+            return None
+        return (
+            "".join(format_tb(record.exc_info[2], limit=self._stack_trace_limit))
+            or None
+        )

--- a/ecs_logging/_utils.py
+++ b/ecs_logging/_utils.py
@@ -11,6 +11,28 @@ except ImportError:
 if TYPE_CHECKING:
     from typing import Any, Dict
 
+try:
+    import collections.abc as collections_abc
+except ImportError:
+    import collections as collections_abc  # type: ignore
+
+try:
+    from functools import lru_cache
+except ImportError:
+    from backports.functools_lru_cache import lru_cache  # type: ignore
+
+
+__all__ = [
+    "collections_abc",
+    "normalize_dict",
+    "de_dot",
+    "merge_dicts",
+    "json_dumps",
+    "TYPE_CHECKING",
+    "typing",
+    "lru_cache",
+]
+
 
 def normalize_dict(value):
     # type: (Dict[str, Any]) -> Dict[str, Any]

--- a/noxfile.py
+++ b/noxfile.py
@@ -9,6 +9,7 @@ def tests_impl(session):
     session.run(
         "pytest",
         "--junitxml=junit-test.xml",
+        "--cov=ecs_logging",
         *(session.posargs or ("tests/",)),
         env={"PYTHONWARNINGS": "always::DeprecationWarning"}
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,11 +22,15 @@ classifiers = [
   "Topic :: System :: Logging",
   "License :: OSI Approved :: Apache Software License"
 ]
+requires = [
+  "backports.functools-lru-cache; python_version < '3.3'"
+]
 requires-python = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [tool.flit.metadata.requires-extra]
 develop = [
     "pytest",
+    "pytest-cov",
     "mock",
     "structlog",
 ]


### PR DESCRIPTION
This work started in https://github.com/elastic/ecs-logging-python/pull/10 by @comcast-jonm ([CLA signed here](https://github.com/elastic/ecs-logging-python/pull/10#issuecomment-626010145)). I've marked them as a co-author of the commit.

Adds the following features:
- `exclude_fields` which given a collection of dotted fields will exclude them since the `StdlibLogger` adds a lot of fields automatically.
- `stack_trace_limit` which mirrors the API for elastic-apm which changes the number of stack traces will be added to the `error.stack_trace` field.
- `process.*` fields are collected automatically