### PR TITLE
Add support for service.name

### DIFF
--- a/ecs_logging/_stdlib.py
+++ b/ecs_logging/_stdlib.py
@@ -165,6 +165,7 @@ class StdlibFormatter(logging.Formatter):
         extras["span.id"] = extras.pop("elasticapm_span_id", None)
         extras["transaction.id"] = extras.pop("elasticapm_transaction_id", None)
         extras["trace.id"] = extras.pop("elasticapm_trace_id", None)
+        extras["service.name"] = extras.pop("elasticapm_service_name", None)
 
         # Merge in any keys that were set within 'extra={...}'
         for field, value in extras.items():

--- a/tests/test_apm.py
+++ b/tests/test_apm.py
@@ -39,6 +39,7 @@ def test_elasticapm_structlog_log_correlation_ecs_fields(spec_validator):
         "span": {"id": span_id},
         "trace": {"id": trace_id},
         "transaction": {"id": transaction_id},
+        "service": {"name": "apm-service"},
     }
 
 
@@ -85,6 +86,7 @@ def test_elastic_apm_stdlib_no_filter_log_correlation_ecs_fields():
         "span": {"id": span_id},
         "trace": {"id": trace_id},
         "transaction": {"id": transaction_id},
+        "service": {"name": "apm-service"},
     }
 
 
@@ -129,6 +131,7 @@ def test_elastic_apm_stdlib_with_filter_log_correlation_ecs_fields():
         "span": {"id": span_id},
         "trace": {"id": trace_id},
         "transaction": {"id": transaction_id},
+        "service": {"name": "apm-service"},
     }
 
 
@@ -174,4 +177,5 @@ def test_elastic_apm_stdlib_exclude_fields():
         },
         "message": "test message",
         "trace": {"id": trace_id},
+        "service": {"name": "apm-service"},
     }


### PR DESCRIPTION
As of 5.10.1, `elastic-apm` provides `service.name` as one of the log correlation fields. This PR supports that new addition.