### PR TITLE
[DOCS] Add link to APM python `LOG_ECS_FORMATTING`

### DIFF
--- a/docs/setup.asciidoc
+++ b/docs/setup.asciidoc
@@ -190,6 +190,10 @@ logger.debug("Example message!")
 from the https://github.com/elastic/apm-agent-python[Elastic APM Python agent] in order to
 https://www.elastic.co/guide/en/apm/agent/python/current/log-correlation.html[correlate logs to spans, transactions and traces] in Elastic APM.
 
+You can also quickly turn on ECS-formatted logs in your python app by setting
+https://www.elastic.co/guide/en/apm/agent/python/master/configuration.html#config-log_ecs_formatting[`LOG_ECS_FORMATTING=override`]
+in the Elastic APM Python agent.
+
 [float]
 [[filebeat]]
 == Install Filebeat


### PR DESCRIPTION
@bmorelli25 There's probably a better way to do this than with the full link. Especially because the full link points to `master`, not current, since current doesn't have it yet.

Closes https://github.com/elastic/apm-agent-python/issues/1007