### PR TITLE
Pull in `event.dataset` for log correlation

### DIFF
--- a/ecs_logging/_stdlib.py
+++ b/ecs_logging/_stdlib.py
@@ -183,6 +183,7 @@ class StdlibFormatter(logging.Formatter):
         extras["transaction.id"] = extras.pop("elasticapm_transaction_id", None)
         extras["trace.id"] = extras.pop("elasticapm_trace_id", None)
         extras["service.name"] = extras.pop("elasticapm_service_name", None)
+        extras["event.dataset"] = extras.pop("elasticapm_event_dataset", None)
 
         # Merge in any keys that were set within 'extra={...}'
         for field, value in extras.items():


### PR DESCRIPTION
Will just be `${service.name}.log`, so pretty redundant but perhaps there will be a reason to have it configurable separate from `service.name` in the future? In any case, it's defined in the [spec](https://github.com/elastic/ecs-logging/blob/master/spec/spec.json#L75-L91).