### PR TITLE
Fix TypeError when exc_info=False

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   (used for the log `message`) and `event.dataset` (a field provided by the
   `elasticapm` integration) ([#46](https://github.com/elastic/ecs-logging-python/pull/46))
 * Add default/fallback handling for json.dumps ([#47](https://github.com/elastic/ecs-logging-python/pull/47))
+* Fixed an issue in `StdLibFormatter` when `exc_info=False` ([#42](https://github.com/elastic/ecs-logging-python/pull/42))
 
 ## 1.0.0 (2021-02-08)
 

--- a/ecs_logging/_stdlib.py
+++ b/ecs_logging/_stdlib.py
@@ -16,6 +16,7 @@
 # under the License.
 
 import logging
+import sys
 import time
 from traceback import format_tb
 from ._meta import ECS_VERSION

--- a/ecs_logging/_stdlib.py
+++ b/ecs_logging/_stdlib.py
@@ -113,22 +113,32 @@ class StdlibFormatter(logging.Formatter):
         self._stack_trace_limit = stack_trace_limit
 
     def _record_error_type(self, record):
-        # upstream doesn't handle booleans for `exc_info`
-        if not record.exc_info:
+        # type: (logging.LogRecord) -> Optional[str]
+        exc_info = record.exc_info
+        if not exc_info:
+            # exc_info is either an iterable or bool. If it doesn't
+            # evaluate to True, then no error type used.
             return None
-        if isinstance(record.exc_info, bool):
-            return sys.exc_info()[0].__name__
-        if isinstance(record.exc_info, (list, tuple)) and record.exc_info[0] is not None:
-            return record.exc_info[0].__name__
+        if isinstance(exc_info, bool):
+            # if it is a bool, then look at sys.exc_info
+            exc_info = sys.exc_info()
+        if isinstance(exc_info, (list, tuple)) and exc_info[0] is not None:
+            return exc_info[0].__name__
+        return None
 
     def _record_error_message(self, record):
-        # upstream doesn't handle booleans for `exc_info`
-        if not record.exc_info:
+        # type: (logging.LogRecord) -> Optional[str]
+        exc_info = record.exc_info
+        if not exc_info:
+            # exc_info is either an iterable or bool. If it doesn't
+            # evaluate to True, then no error message is used.
             return None
-        if isinstance(record.exc_info, bool):
-            return sys.exc_info()[1].__name__
-        elif isinstance(record.exc_info, (list, tuple)) and record.exc_info[1]:
-            return str(record.exc_info[1])
+        if isinstance(exc_info, bool):
+            # if it is a bool, then look at sys.exc_info
+            exc_info = sys.exc_info()
+        if isinstance(exc_info, (list, tuple)) and exc_info[1]:
+            return str(exc_info[1])
+        return None
 
     def format(self, record):
         # type: (logging.LogRecord) -> str

--- a/ecs_logging/_stdlib.py
+++ b/ecs_logging/_stdlib.py
@@ -117,7 +117,7 @@ class StdlibFormatter(logging.Formatter):
         exc_info = record.exc_info
         if not exc_info:
             # exc_info is either an iterable or bool. If it doesn't
-            # evaluate to True, then no error type used.
+            # evaluate to True, then no error type is used.
             return None
         if isinstance(exc_info, bool):
             # if it is a bool, then look at sys.exc_info

--- a/tests/test_stdlib_formatter.py
+++ b/tests/test_stdlib_formatter.py
@@ -183,6 +183,22 @@ def test_stack_trace_limit_disabled(stack_trace_limit, logger):
     assert ecs["log"]["original"] == "there was an error"
 
 
+def test_exc_info_false_does_not_raise(logger):
+    stream = StringIO()
+    handler = logging.StreamHandler(stream)
+    handler.setFormatter(
+        ecs_logging.StdlibFormatter()
+    )
+    logger.addHandler(handler)
+    logger.setLevel(logging.DEBUG)
+
+    logger.info("there was %serror", "no ", exc_info=False)
+
+    ecs = json.loads(stream.getvalue().rstrip())
+    assert ecs["log.level"] == "info"
+    assert ecs["message"] == "there was no error"
+
+
 def test_stack_trace_limit_traceback(logger):
     def f():
         g()

--- a/tests/test_stdlib_formatter.py
+++ b/tests/test_stdlib_formatter.py
@@ -186,9 +186,7 @@ def test_stack_trace_limit_disabled(stack_trace_limit, logger):
 def test_exc_info_false_does_not_raise(logger):
     stream = StringIO()
     handler = logging.StreamHandler(stream)
-    handler.setFormatter(
-        ecs_logging.StdlibFormatter()
-    )
+    handler.setFormatter(ecs_logging.StdlibFormatter())
     logger.addHandler(handler)
     logger.setLevel(logging.DEBUG)
 

--- a/tests/test_stdlib_formatter.py
+++ b/tests/test_stdlib_formatter.py
@@ -195,6 +195,7 @@ def test_exc_info_false_does_not_raise(logger):
     ecs = json.loads(stream.getvalue().rstrip())
     assert ecs["log.level"] == "info"
     assert ecs["message"] == "there was no error"
+    assert "error" not in ecs
 
 
 def test_stack_trace_limit_traceback(logger):


### PR DESCRIPTION
Formatting of a message fails in the `StdlibFormatter` when the
`exc_info` parameter is `False`. The traceback shows that handling of
the boolean is not done correct in the formatting for error type and
message.

```python
Traceback (most recent call last):
  File "lib/python3.8/logging/__init__.py", line 1081, in emit
    msg = self.format(record)
  File "lib/python3.8/logging/__init__.py", line 925, in format
    return fmt.format(record)
  File "ecs_logging/_stdlib.py", line 117, in format
    result = self.format_to_ecs(record)
  File "ecs_logging/_stdlib.py", line 163, in format_to_ecs
    value = extractors[field](record)
  File "ecs_logging/_stdlib.py", line 150, in <lambda>
    if (r.exc_info is not None and r.exc_info[0] is not None)
TypeError: 'bool' object is not subscriptable
```

This replaces the lambda with methods handling `exc_info` being an
boolean or iterable.