### PR TITLE
Add a link to the Python ECS logging tutorial in the Cloud docs

### DIFF
--- a/docs/intro.asciidoc
+++ b/docs/intro.asciidoc
@@ -8,3 +8,5 @@ TIP: Want to learn more about ECS, ECS logging, and other available language plu
 See the {ecs-logging-ref}/intro.html[ECS logging guide].
 
 Ready to jump into `ecs-logging-python`? <<installation,Get started>>.
+
+If you'd like to try out a tutorial using Python ECS logging, see {cloud}/ec-getting-started-search-use-cases-python-logs.html[Ingest logs from a Python application using Filebeat].


### PR DESCRIPTION
This adds a link to a new [Python ECS logging tutorial](https://www.elastic.co/guide/en/cloud/current/ec-getting-started-search-use-cases-python-logs.html) in the Cloud docs.

@bmorelli25, or anyone, please let me know if you think there might be a better place for this link.

Please see also https://github.com/elastic/ecs-logging-nodejs/pull/99