### PR TITLE
Remove .log from event.dataset

### DIFF
--- a/tests/test_apm.py
+++ b/tests/test_apm.py
@@ -56,7 +56,7 @@ def test_elasticapm_structlog_log_correlation_ecs_fields(spec_validator, apm):
         "trace": {"id": trace_id},
         "transaction": {"id": transaction_id},
         "service": {"name": "apm-service"},
-        "event": {"dataset": "apm-service.log"},
+        "event": {"dataset": "apm-service"},
     }
 
 
@@ -100,7 +100,7 @@ def test_elastic_apm_stdlib_no_filter_log_correlation_ecs_fields(apm):
         "trace": {"id": trace_id},
         "transaction": {"id": transaction_id},
         "service": {"name": "apm-service"},
-        "event": {"dataset": "apm-service.log"},
+        "event": {"dataset": "apm-service"},
     }
 
 
@@ -145,7 +145,7 @@ def test_elastic_apm_stdlib_with_filter_log_correlation_ecs_fields(apm):
         "trace": {"id": trace_id},
         "transaction": {"id": transaction_id},
         "service": {"name": "apm-service"},
-        "event": {"dataset": "apm-service.log"},
+        "event": {"dataset": "apm-service"},
     }
 
 
@@ -191,5 +191,5 @@ def test_elastic_apm_stdlib_exclude_fields(apm):
         "message": "test message",
         "trace": {"id": trace_id},
         "service": {"name": "apm-service"},
-        "event": {"dataset": "apm-service.log"},
+        "event": {"dataset": "apm-service"},
     }

--- a/tests/test_structlog_formatter.py
+++ b/tests/test_structlog_formatter.py
@@ -31,7 +31,7 @@ class NotSerializable:
 def make_event_dict():
     return {
         "event": "test message",
-        "event.dataset": "agent.log",
+        "event.dataset": "agent",
         "log.logger": "logger-name",
         "foo": "bar",
         "baz": NotSerializable(),
@@ -56,7 +56,7 @@ def test_event_dict_formatted(time, spec_validator):
         '"message":"test message",'
         '"baz":"<NotSerializable>",'
         '"ecs":{"version":"1.6.0"},'
-        '"event":{"dataset":"agent.log"},'
+        '"event":{"dataset":"agent"},'
         '"foo":"bar",'
         '"log":{"logger":"logger-name"}}'
     )


### PR DESCRIPTION
Fixes some test issues caused by upstream release 6.5.0 of the Python agent