### PR TITLE
Add Python 3.10 classifier, switch from beta to GA

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ author = "Seth Michael Larson"
 author-email = "seth.larson@elastic.co"
 home-page = "https://github.com/elastic/ecs-logging-python"
 classifiers = [
-  "Development Status :: 4 - Beta",
+  "Development Status :: 5 - Production/Stable",
   "Intended Audience :: Developers",
   "Programming Language :: Python :: 2",
   "Programming Language :: Python :: 2.7",
@@ -20,6 +20,7 @@ classifiers = [
   "Programming Language :: Python :: 3.7",
   "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
   "Topic :: System :: Logging",
   "License :: OSI Approved :: Apache Software License"
 ]


### PR DESCRIPTION
Adds explicit Python 3.10 classifier and mark as Stable instead of Beta