### PR TITLE
[CI] Fix [develop] target for twine

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -23,7 +23,10 @@ SOURCE_FILES = ("noxfile.py", "tests/", "ecs_logging/")
 
 def tests_impl(session):
     session.install(".[develop]")
-    session.install(".[master]")
+    # Install `elastic-apm` from master branch
+    session.install(
+        "elastic-apm @ https://github.com/elastic/apm-agent-python/archive/master.zip"
+    )
     session.run(
         "pytest",
         "--junitxml=junit-test.xml",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,10 +37,6 @@ develop = [
     "elastic-apm",
 ]
 
-master = [
-    "elastic-apm @ https://github.com/elastic/apm-agent-python/archive/master.zip",
-]
-
 [tool.flit.metadata.urls]
 "Source" = "https://github.com/elastic/ecs-logging-python"
 "Download" = "https://github.com/elastic/ecs-logging-python/releases"


### PR DESCRIPTION
When I released v1.1.0 `twine` complained about the `[develop]` deps targeting `elastic-apm@master`. Trying this to see if both the CI and `twine` can be pleased.

Ref #68 