### PR TITLE
Revert pre-commit update

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.2.0
+    rev: v4.0.1
     hooks:
     -   id: check-case-conflict
     -   id: check-executables-have-shebangs
@@ -12,12 +12,12 @@ repos:
     -   id: check-jenkins-pipelines
     -   id: check-jjbb
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.950
+    rev: v0.910
     hooks:
     -   id: mypy
         args: [--strict, --show-error-codes, --no-warn-unused-ignores, --implicit-reexport]
 -   repo: https://github.com/ambv/black
-    rev: 22.3.0
+    rev: 21.6b0
     hooks:
     -   id: black
         language_version: python3


### PR DESCRIPTION
`pre-commit-hooks` 4.2.0 [dropped py3.6 support](https://github.com/pre-commit/pre-commit-hooks/releases/tag/v4.2.0), which is why we're failing in jenkins after I did `pre-commit autoupdate`.