### PR TITLE
Add service.environment to stdlib formatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.1.0 (unreleased)
+
+- Add support for `service.environment` from APM log correlation ([#96](https://github.com/elastic/ecs-logging-python/pull/96))
+
 ## 2.0.2 (2023-05-17)
 
 - Allow flit-core 3+ ([#94](https://github.com/elastic/ecs-logging-python/pull/94))

--- a/ecs_logging/_stdlib.py
+++ b/ecs_logging/_stdlib.py
@@ -19,19 +19,20 @@ import logging
 import sys
 import time
 from traceback import format_tb
+
 from ._meta import ECS_VERSION
 from ._utils import (
-    merge_dicts,
-    de_dot,
-    json_dumps,
     TYPE_CHECKING,
     collections_abc,
-    lru_cache,
+    de_dot,
     flatten_dict,
+    json_dumps,
+    lru_cache,
+    merge_dicts,
 )
 
 if TYPE_CHECKING:
-    from typing import Optional, Any, Callable, Dict, Sequence
+    from typing import Any, Callable, Dict, Optional, Sequence
 
     try:
         from typing import Literal, Union  # type: ignore
@@ -235,6 +236,9 @@ class StdlibFormatter(logging.Formatter):
         )
         extras.setdefault("trace.id", extras.pop("elasticapm_trace_id", None))
         extras.setdefault("service.name", extras.pop("elasticapm_service_name", None))
+        extras.setdefault(
+            "service.environment", extras.pop("elasticapm_service_environment", None)
+        )
 
         # Merge in any keys that were set within 'extra={...}'
         for field, value in extras.items():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,14 +15,14 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import collections
 import datetime
 import json
-import os
-import collections
-import sys
 import logging
-import elasticapm
+import os
+import sys
 
+import elasticapm
 import pytest
 
 
@@ -85,7 +85,9 @@ def spec_validator():
 @pytest.fixture
 def apm():
     record_factory = logging.getLogRecordFactory()
-    apm = elasticapm.Client({"SERVICE_NAME": "apm-service", "DISABLE_SEND": True})
+    apm = elasticapm.Client(
+        {"SERVICE_NAME": "apm-service", "ENVIRONMENT": "dev", "DISABLE_SEND": True}
+    )
     yield apm
     apm.close()
     logging.setLogRecordFactory(record_factory)

--- a/tests/test_apm.py
+++ b/tests/test_apm.py
@@ -16,15 +16,15 @@
 # under the License.
 
 import json
-import sys
+import logging
+from io import StringIO
+
 import elasticapm
+import structlog
 from elasticapm.handlers.logging import LoggingFilter
 from elasticapm.handlers.structlog import structlog_processor
+
 import ecs_logging
-import logging
-import structlog
-import pytest
-from io import StringIO
 
 
 def test_elasticapm_structlog_log_correlation_ecs_fields(spec_validator, apm):
@@ -55,7 +55,7 @@ def test_elasticapm_structlog_log_correlation_ecs_fields(spec_validator, apm):
         "span": {"id": span_id},
         "trace": {"id": trace_id},
         "transaction": {"id": transaction_id},
-        "service": {"name": "apm-service"},
+        "service": {"name": "apm-service", "environment": "dev"},
     }
 
 
@@ -98,7 +98,7 @@ def test_elastic_apm_stdlib_no_filter_log_correlation_ecs_fields(apm):
         "span": {"id": span_id},
         "trace": {"id": trace_id},
         "transaction": {"id": transaction_id},
-        "service": {"name": "apm-service"},
+        "service": {"name": "apm-service", "environment": "dev"},
     }
 
 
@@ -142,7 +142,7 @@ def test_elastic_apm_stdlib_with_filter_log_correlation_ecs_fields(apm):
         "span": {"id": span_id},
         "trace": {"id": trace_id},
         "transaction": {"id": transaction_id},
-        "service": {"name": "apm-service"},
+        "service": {"name": "apm-service", "environment": "dev"},
     }
 
 
@@ -187,5 +187,5 @@ def test_elastic_apm_stdlib_exclude_fields(apm):
         },
         "message": "test message",
         "trace": {"id": trace_id},
-        "service": {"name": "apm-service"},
+        "service": {"name": "apm-service", "environment": "dev"},
     }


### PR DESCRIPTION
structlog doesn't need any changes, just a test change.

These tests won't go green until a new version of the python agent is released. Still a chicken and egg problem we haven't resolved. I tested locally with the following:

```
pip install https://github.com/basepi/apm-agent-python/archive/refs/heads/service_environment.zip
```

Ref https://github.com/elastic/apm-agent-python/issues/1772
Depends on https://github.com/elastic/apm-agent-python/pull/1833