### PR TITLE
Move exception stack trace to ECS-compliant field for StructlogFormatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2.1.0 (unreleased)
 
 - Add support for `service.environment` from APM log correlation ([#96](https://github.com/elastic/ecs-logging-python/pull/96))
+- Fix stack trace handling in StructLog for ECS compliance ([#97](https://github.com/elastic/ecs-logging-python/pull/97))
 
 ## 2.0.2 (2023-05-17)
 

--- a/ecs_logging/_structlog.py
+++ b/ecs_logging/_structlog.py
@@ -47,5 +47,13 @@ class StructlogFormatter:
                 )[:-3]
                 + "Z"
             )
+
+        if "exception" in event_dict:
+            stack_trace = event_dict.pop("exception")
+            if "error" in event_dict:
+                event_dict["error"]["stack_trace"] = stack_trace
+            else:
+                event_dict["error"] = {"stack_trace": stack_trace}
+
         event_dict.setdefault("ecs", {}).setdefault("version", ECS_VERSION)
         return event_dict

--- a/tests/test_structlog_formatter.py
+++ b/tests/test_structlog_formatter.py
@@ -92,10 +92,7 @@ def test_can_be_set_as_processor(time, spec_validator):
     )
 
 
-@mock.patch("time.time")
-def test_exception_log_is_ecs_compliant_when_used_with_format_exc_info(time):
-    time.return_value = 1584720997.187709
-
+def test_exception_log_is_ecs_compliant_when_used_with_format_exc_info():
     formatter = ecs_logging.StructlogFormatter()
     formatted_event_dict = json.loads(formatter(None, "debug", event_dict_with_exception()))
 

--- a/tests/test_structlog_formatter.py
+++ b/tests/test_structlog_formatter.py
@@ -16,12 +16,13 @@
 # under the License.
 
 import json
-import ecs_logging
-import structlog
-from unittest import mock
 from io import StringIO
+from unittest import mock
 
 import pytest
+import structlog
+
+import ecs_logging
 
 
 class NotSerializable:
@@ -29,7 +30,8 @@ class NotSerializable:
         return "<NotSerializable>"
 
 
-def make_event_dict():
+@pytest.fixture
+def event_dict():
     return {
         "event": "test message",
         "log.logger": "logger-name",
@@ -38,6 +40,7 @@ def make_event_dict():
     }
 
 
+@pytest.fixture
 def event_dict_with_exception():
     return {
         "event": "test message",
@@ -47,20 +50,19 @@ def event_dict_with_exception():
     }
 
 
-def test_conflicting_event_dict():
+def test_conflicting_event_dict(event_dict):
     formatter = ecs_logging.StructlogFormatter()
-    event_dict = make_event_dict()
     event_dict["foo.bar"] = "baz"
     with pytest.raises(TypeError):
         formatter(None, "debug", event_dict)
 
 
 @mock.patch("time.time")
-def test_event_dict_formatted(time, spec_validator):
+def test_event_dict_formatted(time, spec_validator, event_dict):
     time.return_value = 1584720997.187709
 
     formatter = ecs_logging.StructlogFormatter()
-    assert spec_validator(formatter(None, "debug", make_event_dict())) == (
+    assert spec_validator(formatter(None, "debug", event_dict)) == (
         '{"@timestamp":"2020-03-20T16:16:37.187Z","log.level":"debug",'
         '"message":"test message",'
         '"baz":"<NotSerializable>",'
@@ -92,11 +94,17 @@ def test_can_be_set_as_processor(time, spec_validator):
     )
 
 
-def test_exception_log_is_ecs_compliant_when_used_with_format_exc_info():
+def test_exception_log_is_ecs_compliant_when_used_with_format_exc_info(
+    event_dict_with_exception,
+):
     formatter = ecs_logging.StructlogFormatter()
-    formatted_event_dict = json.loads(formatter(None, "debug", event_dict_with_exception()))
+    formatted_event_dict = json.loads(
+        formatter(None, "debug", event_dict_with_exception)
+    )
 
-    assert "exception" not in formatted_event_dict, "The key 'exception' at the root of a log is not ECS-compliant"
+    assert (
+        "exception" not in formatted_event_dict
+    ), "The key 'exception' at the root of a log is not ECS-compliant"
     assert "error" in formatted_event_dict
     assert "stack_trace" in formatted_event_dict["error"]
     assert "<stack trace here>" in formatted_event_dict["error"]["stack_trace"]


### PR DESCRIPTION
When using the StructlogFormatter, logs with exceptions (e.g. produced by using `logger.exception(...)`) currently result in a `exception` key at the root of the log, which is not a valid ECS field. It should be in the [`error.stack_trace` field](https://www.elastic.co/guide/en/ecs/current/ecs-error.html#field-error-stack-trace) instead. 

This PR addresses a small part of the [disparity between the StructlogFormatter and the StdlibFormatter ](https://github.com/elastic/ecs-logging-python/issues/73). Until that is addressed in it's entirety, this patch will help users of this package (like myself) to output logs that comply with the ECS specification.