### PR TITLE
fix: use fromtimestamp instead of deprecated utcfromtimestamp

### DIFF
--- a/ecs_logging/__init__.py
+++ b/ecs_logging/__init__.py
@@ -20,7 +20,7 @@ from ._meta import ECS_VERSION
 from ._stdlib import StdlibFormatter
 from ._structlog import StructlogFormatter
 
-__version__ = "2.1.1"
+__version__ = "2.1.0"
 __all__ = [
     "ECS_VERSION",
     "StdlibFormatter",

--- a/ecs_logging/__init__.py
+++ b/ecs_logging/__init__.py
@@ -20,7 +20,7 @@ from ._meta import ECS_VERSION
 from ._stdlib import StdlibFormatter
 from ._structlog import StructlogFormatter
 
-__version__ = "2.1.0"
+__version__ = "2.1.1"
 __all__ = [
     "ECS_VERSION",
     "StdlibFormatter",

--- a/ecs_logging/_structlog.py
+++ b/ecs_logging/_structlog.py
@@ -42,9 +42,9 @@ class StructlogFormatter:
         # type: (Dict[str, Any]) -> Dict[str, Any]
         if "@timestamp" not in event_dict:
             event_dict["@timestamp"] = (
-                datetime.datetime.utcfromtimestamp(time.time()).strftime(
-                    "%Y-%m-%dT%H:%M:%S.%f"
-                )[:-3]
+                datetime.datetime.fromtimestamp(
+                    time.time(), tz=datetime.timezone.utc
+                ).strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3]
                 + "Z"
             )
 


### PR DESCRIPTION
Version 3.12 of python deprecated the utcfromtimestamp, this PR uses the correct method.