### PR TITLE
Generalize documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ See the [ECS Logging Python reference](https://www.elastic.co/guide/en/ecs-loggi
 
 ## Elastic APM Log Correlation
 
-`ecs-logging-python` supports automatically collecting [ECS tracing fields](https://www.elastic.co/guide/en/ecs/master/ecs-tracing.html)
+`ecs-logging-python` supports automatically collecting [ECS tracing fields](https://www.elastic.co/guide/en/ecs/current/ecs-tracing.html)
 from the [Elastic APM Python agent](https://github.com/elastic/apm-agent-python) in order to
 [correlate logs to spans, transactions and traces](https://www.elastic.co/guide/en/apm/agent/python/current/log-correlation.html) in Elastic APM.
 

--- a/docs/setup.asciidoc
+++ b/docs/setup.asciidoc
@@ -191,7 +191,7 @@ logger.debug("Example message!")
 
 `ecs-logging-python` supports automatically collecting  {ecs-ref}/ecs-tracing.html[ECS tracing fields]
 from the https://github.com/elastic/apm-agent-python[Elastic APM Python agent] in order to
-{apm-py-ref}/log-correlation.html[correlate logs to spans, transactions and traces] in Elastic APM.
+{apm-py-ref}/logs.html[correlate logs to spans, transactions and traces] in Elastic APM.
 
 You can also quickly turn on ECS-formatted logs in your python app by setting
 {apm-py-ref}/configuration.html#config-log_ecs_reformatting[`LOG_ECS_REFORMATTING=override`]

--- a/docs/setup.asciidoc
+++ b/docs/setup.asciidoc
@@ -189,12 +189,12 @@ logger.debug("Example message!")
 [[correlation]]
 == Elastic APM Log Correlation
 
-`ecs-logging-python` supports automatically collecting https://www.elastic.co/guide/en/ecs/master/ecs-tracing.html[ECS tracing fields]
+`ecs-logging-python` supports automatically collecting  {ecs-ref}/ecs-tracing.html[ECS tracing fields]
 from the https://github.com/elastic/apm-agent-python[Elastic APM Python agent] in order to
-https://www.elastic.co/guide/en/apm/agent/python/current/log-correlation.html[correlate logs to spans, transactions and traces] in Elastic APM.
+{apm-py-ref}/log-correlation.html[correlate logs to spans, transactions and traces] in Elastic APM.
 
 You can also quickly turn on ECS-formatted logs in your python app by setting
-https://www.elastic.co/guide/en/apm/agent/python/master/configuration.html#config-log_ecs_reformatting[`LOG_ECS_REFORMATTING=override`]
+{apm-py-ref}/configuration.html#config-log_ecs_reformatting[`LOG_ECS_REFORMATTING=override`]
 in the Elastic APM Python agent.
 
 [float]


### PR DESCRIPTION
Relates to https://github.com/elastic/docs/pull/2994

This PR updates some links in the [ECS Logging Python Reference](https://www.elastic.co/guide/en/ecs-logging/python/current/index.html) to use shared attributes for some documentation links, so that they stay up-to-date.