### PR TITLE
Rewrite type annotations

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
       with:
-        python-version: '3.7'
+        python-version: '3.10'
     - run: .ci/scripts/lint.sh
 
   test:

--- a/ecs_logging/_structlog.py
+++ b/ecs_logging/_structlog.py
@@ -17,18 +17,16 @@
 
 import time
 import datetime
-from ._meta import ECS_VERSION
-from ._utils import json_dumps, normalize_dict, TYPE_CHECKING
+from typing import Any, Dict
 
-if TYPE_CHECKING:
-    from typing import Any, Dict
+from ._meta import ECS_VERSION
+from ._utils import json_dumps, normalize_dict
 
 
 class StructlogFormatter:
     """ECS formatter for the ``structlog`` module"""
 
-    def __call__(self, _, name, event_dict):
-        # type: (Any, str, Dict[str, Any]) -> str
+    def __call__(self, _: Any, name: str, event_dict: Dict[str, Any]) -> str:
 
         # Handle event -> message now so that stuff like `event.dataset` doesn't
         # cause problems down the line
@@ -38,8 +36,7 @@ class StructlogFormatter:
         event_dict = self.format_to_ecs(event_dict)
         return self._json_dumps(event_dict)
 
-    def format_to_ecs(self, event_dict):
-        # type: (Dict[str, Any]) -> Dict[str, Any]
+    def format_to_ecs(self, event_dict: Dict[str, Any]) -> Dict[str, Any]:
         if "@timestamp" not in event_dict:
             event_dict["@timestamp"] = (
                 datetime.datetime.fromtimestamp(
@@ -58,6 +55,5 @@ class StructlogFormatter:
         event_dict.setdefault("ecs.version", ECS_VERSION)
         return event_dict
 
-    def _json_dumps(self, value):
-        # type: (Dict[str, Any]) -> str
+    def _json_dumps(self, value: Dict[str, Any]) -> str:
         return json_dumps(value=value)

--- a/ecs_logging/_utils.py
+++ b/ecs_logging/_utils.py
@@ -15,52 +15,28 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import collections.abc
 import json
 import functools
-
-try:
-    import typing
-
-    TYPE_CHECKING = typing.TYPE_CHECKING
-except ImportError:
-    typing = None  # type: ignore
-    TYPE_CHECKING = False
-
-if TYPE_CHECKING:
-    from typing import Any, Dict
-
-try:
-    import collections.abc as collections_abc
-except ImportError:
-    import collections as collections_abc  # type: ignore
-
-try:
-    from functools import lru_cache
-except ImportError:
-    from backports.functools_lru_cache import lru_cache  # type: ignore
+from typing import Any, Dict, Mapping
 
 
 __all__ = [
-    "collections_abc",
     "normalize_dict",
     "de_dot",
     "merge_dicts",
     "json_dumps",
-    "TYPE_CHECKING",
-    "typing",
-    "lru_cache",
 ]
 
 
-def flatten_dict(value):
-    # type: (typing.Mapping[str, Any]) -> Dict[str, Any]
+def flatten_dict(value: Mapping[str, Any]) -> Dict[str, Any]:
     """Adds dots to all nested fields in dictionaries.
     Raises an error if there are entries which are represented
     with different forms of nesting. (ie {"a": {"b": 1}, "a.b": 2})
     """
     top_level = {}
     for key, val in value.items():
-        if not isinstance(val, collections_abc.Mapping):
+        if not isinstance(val, collections.abc.Mapping):
             if key in top_level:
                 raise ValueError(f"Duplicate entry for '{key}' with different nesting")
             top_level[key] = val
@@ -77,8 +53,7 @@ def flatten_dict(value):
     return top_level
 
 
-def normalize_dict(value):
-    # type: (Dict[str, Any]) -> Dict[str, Any]
+def normalize_dict(value: Dict[str, Any]) -> Dict[str, Any]:
     """Expands all dotted names to nested dictionaries"""
     if not isinstance(value, dict):
         return value
@@ -94,8 +69,7 @@ def normalize_dict(value):
     return value
 
 
-def de_dot(dot_string, msg):
-    # type: (str, Any) -> Dict[str, Any]
+def de_dot(dot_string: str, msg: Any) -> Dict[str, Any]:
     """Turn value and dotted string key into a nested dictionary"""
     arr = dot_string.split(".")
     ret = {arr[-1]: msg}
@@ -104,8 +78,7 @@ def de_dot(dot_string, msg):
     return ret
 
 
-def merge_dicts(from_, into):
-    # type: (Dict[Any, Any], Dict[Any, Any]) -> Dict[Any, Any]
+def merge_dicts(from_: Dict[Any, Any], into: Dict[Any, Any]) -> Dict[Any, Any]:
     """Merge deeply nested dictionary structures.
     When called has side-effects within 'destination'.
     """
@@ -125,8 +98,7 @@ def merge_dicts(from_, into):
     return into
 
 
-def json_dumps(value):
-    # type: (Dict[str, Any]) -> str
+def json_dumps(value: Dict[str, Any]) -> str:
 
     # Ensure that the first three fields are '@timestamp',
     # 'log.level', and 'message' per ECS spec
@@ -175,8 +147,7 @@ def json_dumps(value):
         return json_dumps(value)
 
 
-def _json_dumps_fallback(value):
-    # type: (Any) -> Any
+def _json_dumps_fallback(value: Any) -> Any:
     """
     Fallback handler for json.dumps to handle objects json doesn't know how to
     serialize.


### PR DESCRIPTION
Move from comments to Python 3 type annotations. While at it cleanup also imports.

Fix #79