### PR TITLE
Bump baseline supported version to Python 3.8

### DIFF
--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        python: [ '3.7', '3.8', '3.9', '3.10', '3.11', '3.12' ]
+        python: [ '3.8', '3.9', '3.10', '3.11', '3.12', '3.13' ]
       fail-fast: false
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -23,7 +23,7 @@ jobs:
     timeout-minutes: 5
     strategy:
       matrix:
-        python: [ '3.7', '3.8', '3.9', '3.10', '3.11', '3.12' ]
+        python: [ '3.8', '3.9', '3.10', '3.11', '3.12', '3.13' ]
       fail-fast: false
     steps:
     - run: 'echo "No build required"'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        python: [ '3.7', '3.8', '3.9', '3.10', '3.11', '3.12' ]
+        python: [ '3.8', '3.9', '3.10', '3.11', '3.12', '3.13' ]
       fail-fast: false
     steps:
     - uses: actions/checkout@v4

--- a/noxfile.py
+++ b/noxfile.py
@@ -36,7 +36,7 @@ def tests_impl(session):
     )
 
 
-@nox.session(python=["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12"])
+@nox.session(python=["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"])
 def test(session):
     tests_impl(session)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,18 +13,17 @@ classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Intended Audience :: Developers",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.6",
-  "Programming Language :: Python :: 3.7",
   "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Topic :: System :: Logging",
   "License :: OSI Approved :: Apache Software License"
 ]
 requires = []
-requires-python = ">=3.6"
+requires-python = ">=3.8"
 
 [tool.flit.metadata.requires-extra]
 develop = [

--- a/tests/test_stdlib_formatter.py
+++ b/tests/test_stdlib_formatter.py
@@ -99,9 +99,11 @@ def test_can_be_set_on_handler():
     )
 
 
+@mock.patch("time.time_ns")
 @mock.patch("time.time")
-def test_extra_is_merged(time, logger):
+def test_extra_is_merged(time, time_ns, logger):
     time.return_value = 1584720997.187709
+    time_ns.return_value = time.return_value * 1_000_000_000
 
     stream = StringIO()
     handler = logging.StreamHandler(stream)


### PR DESCRIPTION
Bump to Python 3.8 as baseline and add 3.13 support. We have to drop 3.7 testing because it's not available anymore with github setup python action.