### PR TITLE
Cache and expose extractors

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,16 +1,16 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.0.1
+    rev: v5.0.0
     hooks:
       - id: check-case-conflict
       - id: check-executables-have-shebangs
       - id: check-merge-conflict
   - repo: https://github.com/elastic/apm-pipeline-library
-    rev: current
+    rev: v1.19.13
     hooks:
       - id: check-bash-syntax
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.910
+    rev: v1.15.0
     hooks:
       - id: mypy
         args:
@@ -21,12 +21,12 @@ repos:
             --implicit-reexport,
           ]
   - repo: https://github.com/psf/black
-    rev: 22.12.0
+    rev: 25.1.0
     hooks:
       - id: black
         language_version: python3
   - repo: https://github.com/pycqa/flake8
-    rev: 3.9.2
+    rev: 7.1.1
     hooks:
       - id: flake8
         exclude: tests|conftest.py|setup.py

--- a/ecs_logging/_stdlib.py
+++ b/ecs_logging/_stdlib.py
@@ -30,12 +30,7 @@ from ._utils import (
     merge_dicts,
 )
 
-from typing import Any, Callable, Dict, Optional, Sequence, Union
-
-try:
-    from typing import Literal  # type: ignore
-except ImportError:
-    from typing_extensions import Literal  # type: ignore
+from typing import Any, Callable, Dict, Optional, Sequence, Union, Literal
 
 
 # Load the attributes of a LogRecord so if some are

--- a/ecs_logging/_stdlib.py
+++ b/ecs_logging/_stdlib.py
@@ -159,21 +159,25 @@ class StdlibFormatter(logging.Formatter):
         result = self.format_to_ecs(record)
         return json_dumps(result)
 
-    def format_to_ecs(self, record: logging.LogRecord) -> Dict[str, Any]:
-        """Function that can be overridden to add additional fields to
-        (or remove fields from) the JSON before being dumped into a string.
+    @property
+    @lru_cache
+    def extractors(self) -> Dict[str, Callable[[logging.LogRecord], Any]]:
+        """Property that can be overridden to add additional field
+        extractors to (or remove fields from) the JSON before being
+        dumped into a string.
 
          .. code-block: python
 
             class MyFormatter(StdlibFormatter):
-                def format_to_ecs(self, record):
-                  result = super().format_to_ecs(record)
-                  del result["log"]["original"]   # remove unwanted field(s)
-                  result["my_field"] = "my_value" # add custom field
-                  return result
+                @property
+                @lru_cache
+                def extractors(self):
+                    extractors = super().extractors
+                    del extractors["log.original"]   # remove unwanted field(s)
+                    extractors["my_field"] = self._my_extractor # add custom field
+                    return extractors
         """
-
-        extractors: Dict[str, Callable[[logging.LogRecord], Any]] = {
+        return {
             "@timestamp": self._record_timestamp,
             "ecs.version": lambda _: ECS_VERSION,
             "log.level": lambda r: (r.levelname.lower() if r.levelname else None),
@@ -191,11 +195,24 @@ class StdlibFormatter(logging.Formatter):
             "error.stack_trace": self._record_error_stack_trace,
         }
 
+    def format_to_ecs(self, record: logging.LogRecord) -> Dict[str, Any]:
+        """Function that can be overridden to add additional fields to
+        (or remove fields from) the JSON before being dumped into a string.
+
+         .. code-block: python
+
+            class MyFormatter(StdlibFormatter):
+                def format_to_ecs(self, record):
+                  result = super().format_to_ecs(record)
+                  del result["log"]["original"]   # remove unwanted field(s)
+                  result["my_field"] = "my_value" # add custom field
+                  return result
+        """
         result: Dict[str, Any] = {}
-        for field in set(extractors.keys()).difference(self._exclude_fields):
+        for field in set(self.extractors.keys()).difference(self._exclude_fields):
             if self._is_field_excluded(field):
                 continue
-            value = extractors[field](record)
+            value = self.extractors[field](record)
             if value is not None:
                 # special case ecs.version that should not be de-dotted
                 if field == "ecs.version":


### PR DESCRIPTION
This PR caches and exposes the `extractors` dict for two purposes:

- Loads the dict only during initialization, instead of on every logger invocation.
- Provides a clearer and more scalable way to subclass `StdlibFormatter`.

This is an adapted use case from the library we use for several services in our company that adds information about errors in HTTP requests :

```python
from typing import TYPE_CHECKING
from functools import lru_cache

from ecs_logging import StdlibFormatter
import httpx

if TYPE_CHECKING:
    from logging import LogRecord


httpx._utils.SENSITIVE_HEADERS.update({
    'apikey', 'api-key', 'x-api-key', 'x-auth-token',
})


class EcsFormatter(StdlibFormatter):

    @property
    @lru_cache
    def extractors(self):
        extractors = super().extractors
        extractors['http'] = self._extract_httpx_response
        return extractors

    def _extract_httpx_response(self, record: 'LogRecord') -> dict | None:
        if not record.exc_info or not isinstance(record.exc_info[1], httpx.HTTPStatusError):
            return None

        resp = record.exc_info[1].response

        redact = lambda x: dict(httpx._utils.obfuscate_sensitive_headers(x.multi_items()))

        if (url := resp.request.url).password:
            url = str(url).replace(f':{url.password}@', ':[secure]@')

        return {
            'version':          resp.http_version,
            'request':  {
                'method':       resp.request.method,
                'url':          str(url),
                'headers':      redact(resp.request.headers),
                'body.content': resp.request.content,
            },
            'response': {
                'status_code':  resp.status_code,
                'headers':      redact(resp.headers),
                'body.content': resp.content,
            }
        }

```

Additionally, this PR also:

- Removes unnecessary try/catch on `Literal` import. [`Literal` was added in Python 3.8](https://docs.python.org/3/whatsnew/3.8.html#typing).
- Updates `pre-commit`'s config avoiding two warnings.
