### PR TITLE
Fix lint issues in ecs_logging/_stdlib.py

### DIFF
--- a/ecs_logging/_stdlib.py
+++ b/ecs_logging/_stdlib.py
@@ -46,6 +46,10 @@ except Exception:  # LogRecord signature changed?
     _LOGRECORD_DIR = set()
 
 
+def _converter(secs: Optional[float] = None) -> time.struct_time:
+    return time.gmtime(secs)
+
+
 class StdlibFormatter(logging.Formatter):
     """ECS Formatter for the standard library ``logging`` module"""
 
@@ -73,7 +77,8 @@ class StdlibFormatter(logging.Formatter):
         "process",
         "message",
     } | _LOGRECORD_DIR
-    converter = time.gmtime
+
+    convert = _converter
 
     def __init__(
         self,


### PR DESCRIPTION
This commit addresses linting issues reported by `mypy` e.g. in https://github.com/elastic/ecs-logging-python/actions/runs/15781106393/job/44486719657?pr=171