### PR TITLE
Fix typo identified in #172

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
     hooks:
       - id: check-bash-syntax
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.910
+    rev: v1.16.1
     hooks:
       - id: mypy
         args:

--- a/ecs_logging/_stdlib.py
+++ b/ecs_logging/_stdlib.py
@@ -73,9 +73,7 @@ class StdlibFormatter(logging.Formatter):
         "process",
         "message",
     } | _LOGRECORD_DIR
-    converter: Callable[[Optional[float]], time.struct_time] = staticmethod(
-        time.gmtime
-    )
+    converter: Callable[[Optional[float]], time.struct_time] = staticmethod(time.gmtime)
 
     def __init__(
         self,

--- a/ecs_logging/_stdlib.py
+++ b/ecs_logging/_stdlib.py
@@ -73,7 +73,7 @@ class StdlibFormatter(logging.Formatter):
         "process",
         "message",
     } | _LOGRECORD_DIR
-    converter: Callable[[float | None], time.struct_time] = staticmethod(time.gmtime)
+    converter: Callable[Union[float, None], time.struct_time] = staticmethod(time.gmtime)
 
     def __init__(
         self,

--- a/ecs_logging/_stdlib.py
+++ b/ecs_logging/_stdlib.py
@@ -73,7 +73,9 @@ class StdlibFormatter(logging.Formatter):
         "process",
         "message",
     } | _LOGRECORD_DIR
-    converter: Callable[Union[float, None], time.struct_time] = staticmethod(time.gmtime)
+    converter: Callable[[Union[float, None]], time.struct_time] = staticmethod(
+        time.gmtime
+    )
 
     def __init__(
         self,

--- a/ecs_logging/_stdlib.py
+++ b/ecs_logging/_stdlib.py
@@ -73,7 +73,7 @@ class StdlibFormatter(logging.Formatter):
         "process",
         "message",
     } | _LOGRECORD_DIR
-    converter: Callable[[Union[float, None]], time.struct_time] = staticmethod(
+    converter: Callable[[Optional[float]], time.struct_time] = staticmethod(
         time.gmtime
     )
 

--- a/ecs_logging/_stdlib.py
+++ b/ecs_logging/_stdlib.py
@@ -46,10 +46,6 @@ except Exception:  # LogRecord signature changed?
     _LOGRECORD_DIR = set()
 
 
-def _converter(secs: Optional[float] = None) -> time.struct_time:
-    return time.gmtime(secs)
-
-
 class StdlibFormatter(logging.Formatter):
     """ECS Formatter for the standard library ``logging`` module"""
 
@@ -77,8 +73,7 @@ class StdlibFormatter(logging.Formatter):
         "process",
         "message",
     } | _LOGRECORD_DIR
-
-    convert = _converter
+    converter: Callable[[float | None], time.struct_time] = staticmethod(time.gmtime)
 
     def __init__(
         self,


### PR DESCRIPTION
This commit fixes a typo observed in
https://github.com/elastic/ecs-logging-python/pull/172#discussion_r2166707106

Also allows to simply the code without a need for a helper function.